### PR TITLE
feature/dynamic-controls

### DIFF
--- a/src/components/GeoJsonLayer.svelte
+++ b/src/components/GeoJsonLayer.svelte
@@ -3,6 +3,7 @@
 	import L from 'leaflet';
     import chroma from "chroma-js";
 
+    export let id;
     export let url;
     export let name;
     export let onStyle = undefined;
@@ -24,12 +25,12 @@
 
         //const leafletMap = map();
         layer = onStyle == null ? L.geoJSON(data) : L.geoJSON(data, {style: onStyle});
-        dispatch('create-layer', {layer, url, name});
+        dispatch('create-layer', {layer, url, name, id});
 
         return () => {
             //const leafletMap = map();
             //leafletMap.removeFrom(layer);
-            dispatch('remove-layer', {url, name});
+            dispatch('remove-layer', {url, name, id});
         }
     };
 

--- a/src/components/LayerControl.svelte
+++ b/src/components/LayerControl.svelte
@@ -11,6 +11,7 @@
     let control = undefined;
     let layers = [];
     let layersMap = {};
+    let layersNameToIdMap = {};
 
     const map = getContext('map');
 
@@ -19,11 +20,13 @@
     });
 
     const overlayAdd = (layer) => {
-        $layersStore[layer.name] = true;
+        const layerId = layersNameToIdMap[layer.name];
+        $layersStore[layerId] = true;
     }
 
     const overlayRemove = (layer) => {
-        $layersStore[layer.name] = false;
+        const layerId = layersNameToIdMap[layer.name];
+        $layersStore[layerId] = false;
     }
 
     const createControl = async (container) => {
@@ -41,17 +44,19 @@
     };
 
     const addLayer = (event: any) => {
-        const { layer, name, url } = event.detail;
+        const { layer, name, url, id } = event.detail;
         control.addOverlay(layer, name);
         layersMap[name] = layer;
-        $layersStore[name] = false;
+        layersNameToIdMap[name] = id;
+        $layersStore[id] = false;
     };
 
     const removeLayer = (event: any) => {
-        const { name, url } = event.detail;
+        const { name, url, id } = event.detail;
         control.removeLayer(layersMap[name]);
         delete layersMap[name];
-        delete $layersStore[name];
+        delete layersNameToIdMap[name];
+        delete $layersStore[id];
     }
 
 </script>

--- a/src/components/LayerCreator.svelte
+++ b/src/components/LayerCreator.svelte
@@ -3,12 +3,12 @@
     import LayerByIncome from './LayerByIncome.svelte';
     import type { Layer } from '../config';
 
-    export function CreateLayer(layerConfig: Layer) {
-        if (layerConfig.name === 'New York City Income') {
-            return {component: LayerByIncome, ...layerConfig};
+    export function CreateLayer(layer: Layer) {
+        if (layer.property?.name === 'New York City Income') {
+            return {component: LayerByIncome, ...layer.property};
         }
 
-        return {component: GeoJsonLayer, ...layerConfig};
+        return {component: GeoJsonLayer, ...layer.property};
     }
 
 </script>

--- a/src/components/Story.svelte
+++ b/src/components/Story.svelte
@@ -4,17 +4,12 @@
   import { layersStore, incomeSlider } from '../stores.js';
   import Paper, { Title, Subtitle, Content } from '@smui/paper';
   import config from '../configs/config.json';
-  import { CreateControl } from './controls/ControlCreator.svelte';
+  import { CreateControls } from './controls/ControlCreator.svelte';
 
   let controls = [];
 
   onMount(async () => {
-      const controlPromises = config.layers
-        .map((layerConfig: Layer) => layerConfig.controlProperties?.map(l => {
-            return {idLayer: layerConfig.id, nameLayer: layerConfig.name, controlProperties: l}}))
-        .filter(x => x !== undefined)
-        .flat()
-        .map(x => CreateControl(x.controlProperties, x.idLayer, x.nameLayer));
+      const controlPromises = CreateControls(config.layers);
 
       // await everything here, otherwise the components will try to load before they
       // are properly setup. For now, we will filter out any bad layers.
@@ -26,7 +21,7 @@
 
 <!-- hacky solution until I learn about the svelte css better. Otherwise, the if ignores the class -->
 <div class="panel">
-{#if $layersStore['New York City Income']}
+{#if $layersStore['NewYorkCityIncome'] == true}
 <Paper>
     <Title>NYC INCOME - {$incomeSlider > 225 ? 'All' : `$${$incomeSlider * 1000}`}</Title>
     <Subtitle>Select income. Darker areas mean higher percentage below slider</Subtitle>
@@ -46,14 +41,13 @@
 </div>
 
 {#if config}
-    {#each controls as {component, idLayer, nameLayer, ...props}}
-        {#if $layersStore[idLayer] == true}
+    {#each controls as {component, layerProperty, controlProperty}}
+        {#if $layersStore[layerProperty.id] == true}
             <div class="panel">
                 <svelte:component
                     this={component}
-                    idLayer={idLayer}
-                    nameLayer={nameLayer}
-                    controlProperty={props} />
+                    layerProperty={layerProperty}
+                    controlProperty={controlProperty} />
             </div>
         {/if}
     {/each}

--- a/src/components/controls/Control.svelte
+++ b/src/components/controls/Control.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import Paper, { Title, Subtitle, Content } from '@smui/paper';
+  import type { ControlProperty } from '../../config';
+
+  export let idLayer: string;
+  export let nameLayer: string;
+  export let controlProperty: ControlProperty = undefined;
+</script>
+
+<Paper>
+    <Title>{controlProperty.title || nameLayer}</Title>
+        <Subtitle>{controlProperty.subtitle}</Subtitle>
+    <Content>
+        <slot />
+    </Content>
+</Paper>
+
+<style>
+</style>

--- a/src/components/controls/Control.svelte
+++ b/src/components/controls/Control.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
   import Paper, { Title, Subtitle, Content } from '@smui/paper';
-  import type { ControlProperty } from '../../config';
+  import type { ControlProperty, LayerProperty } from '../../config';
 
-  export let idLayer: string;
-  export let nameLayer: string;
+  export let layerProperty: LayerProperty;
   export let controlProperty: ControlProperty = undefined;
 </script>
 
 <Paper>
-    <Title>{controlProperty.title || nameLayer}</Title>
+    <Title>{controlProperty.title || layerProperty.name}</Title>
         <Subtitle>{controlProperty.subtitle}</Subtitle>
     <Content>
         <slot />

--- a/src/components/controls/ControlCreator.svelte
+++ b/src/components/controls/ControlCreator.svelte
@@ -1,0 +1,21 @@
+<script context="module" lang="ts">
+    import FlyTo from './FlyTo.svelte';
+    import Control from './Control.svelte';
+    //import Slider from './Slider.svelte';
+    import type { ControlProperty } from '../config';
+
+    export async function CreateControl(controlProperty: ControlProperty, idLayer: string, nameLayer: string?) {
+        let component;
+
+        switch (controlProperty.type) {
+            case 'flyTo':
+                component = FlyTo;
+                break;
+            default:
+                component = Control;
+        }
+        return {component, name, idLayer, nameLayer, ...controlProperty };
+    }
+
+</script>
+

--- a/src/components/controls/ControlCreator.svelte
+++ b/src/components/controls/ControlCreator.svelte
@@ -2,9 +2,10 @@
     import FlyTo from './FlyTo.svelte';
     import Control from './Control.svelte';
     //import Slider from './Slider.svelte';
-    import type { ControlProperty } from '../config';
+    import type { Layer, ControlProperty, LayerProperty } from '../config';
 
-    export async function CreateControl(controlProperty: ControlProperty, idLayer: string, nameLayer: string?) {
+    // NOTE: this is async in antication for dynamically loading components. that feature is async.
+    export async function CreateControl(controlProperty: ControlProperty, layerProperty: LayerProperty) {
         let component;
 
         switch (controlProperty.type) {
@@ -14,7 +15,20 @@
             default:
                 component = Control;
         }
-        return {component, name, idLayer, nameLayer, ...controlProperty };
+        return {component, controlProperty, layerProperty};
+    }
+
+    /**
+     * Given a list of layers, flatten out the layers with the control properties
+     * to return a list of promises that will resolve into control components
+     */
+    export function CreateControls(layers: Layer[]) {
+        return layers
+            .map(layer => layer.controlProperties?.map(controlProperty => {
+                return {controlProperty, layerProperty: layer.property};}))
+            .flat()
+            .filter(x => x !== undefined)
+            .map(({controlProperty, layerProperty}) => CreateControl(controlProperty, layerProperty));
     }
 
 </script>

--- a/src/components/controls/FlyTo.svelte
+++ b/src/components/controls/FlyTo.svelte
@@ -18,7 +18,8 @@
   });
 
   function panTo(): void {
-    map?.flyTo(new LatLng(40.68967735303955, -74.04534588323135), 15);
+    const { lat, lng, zoom } = controlProperty.args;
+    map?.flyTo(new LatLng(lat, lng), zoom);
   }
 
   onDestroy(unsubscribe);

--- a/src/components/controls/FlyTo.svelte
+++ b/src/components/controls/FlyTo.svelte
@@ -5,8 +5,7 @@
   import type { ControlProperty } from '../../config';
   import Control from './Control.svelte';
 
-  export let idLayer: string;
-  export let nameLayer: string;
+  export let layerProperty: LayerProperty;
   export let controlProperty: ControlProperty = undefined;
 
   let map: Map|undefined = undefined;
@@ -25,8 +24,8 @@
   onDestroy(unsubscribe);
 </script>
 
-<Control nameLayer={nameLayer} idLayer={idLayer} controlProperty={controlProperty}>
-    <button on:click={panTo}>Fly To {controlProperty.title || nameLayer}</button>
+<Control layerProperty={layerProperty} controlProperty={controlProperty}>
+    <button on:click={panTo}>Fly To {controlProperty.title || layerProperty.name}</button>
 </Control>
 
 <style>

--- a/src/components/controls/FlyTo.svelte
+++ b/src/components/controls/FlyTo.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { LatLng, Map } from 'leaflet';
+  import { onDestroy } from 'svelte';
+  import { mapStore } from '../../stores.js';
+  import type { ControlProperty } from '../../config';
+  import Control from './Control.svelte';
+
+  export let idLayer: string;
+  export let nameLayer: string;
+  export let controlProperty: ControlProperty = undefined;
+
+  let map: Map|undefined = undefined;
+
+  const unsubscribe = mapStore.subscribe((newMap: Map|null) => {
+    if (newMap != null) {
+      map = newMap;
+    }
+  });
+
+  function panTo(): void {
+    map?.flyTo(new LatLng(40.68967735303955, -74.04534588323135), 15);
+  }
+
+  onDestroy(unsubscribe);
+</script>
+
+<Control nameLayer={nameLayer} idLayer={idLayer} controlProperty={controlProperty}>
+    <button on:click={panTo}>Fly To {controlProperty.title || nameLayer}</button>
+</Control>
+
+<style>
+</style>
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,10 +8,14 @@ export default interface Config {
 
 export interface Layer {
   id: string,
+  property: LayerProperty,
+  controlProperties?: ControlProperty[]
+}
+
+export interface LayerProperty {
   name: string,
   url: string,
   type: 'geojson'|'raster',
-  controlProperties?: ControlProperty[]
 }
 
 export interface Story {
@@ -27,5 +31,6 @@ export interface ControlProperty {
   key?: string,
   prefixKey?: string,
   // generic arguments that depends on the type
+  // FIXME remove any
   args: any
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,8 @@ export interface Story {
 export interface ControlProperty {
   id: string,
   type: 'slider',
+  title?: string,
+  subtitle?: string,
   key?: string,
   prefixKey?: string
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,14 +16,16 @@ export interface Layer {
 
 export interface Story {
   title: string,
-  content: string
+  content: string,
 }
 
 export interface ControlProperty {
   id: string,
-  type: 'slider',
+  type?: 'slider'|'flyTo',
   title?: string,
   subtitle?: string,
   key?: string,
-  prefixKey?: string
+  prefixKey?: string,
+  // generic arguments that depends on the type
+  args: any
 }


### PR DESCRIPTION
- added dynamic controls based on the config file
- replaced the controls in the story
- only replaced the FlyTo control so far

I have a config set up similar to the following
```
  "layers": [
    {
     "property": {
        "id": "StatueOfLiberty",
        "name": "Statue of Liberty",
        "type": "geojson",
        "url": "layers/statue-of-liberty.geojson"
      },
      "controlProperties": [
        {
          "id": "flyTo",   
          "type": "flyTo", 
          "subtitle": "This is the Statue of Liberty",
          "args": {                                                                                      
            "lat": 40.68967735303955,
            "lng": -74.04534588323135,
            "zoom": 15
          }
        },
        {  
          "id": "info",
          "subtitle": "This is some information on the Statue of Liberty"
        }                                                                                      
      ]                                                                                        
    },
....    
```

This creates two controls. One is a fly to button. The other is just a read only component with the subtitle.